### PR TITLE
Optimize UI for portrait touchscreen

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3,6 +3,19 @@
 body {
   font-family: 'Barlow', sans-serif;
   touch-action: manipulation;
+  font-size: 1rem;
+}
+
+@media (min-width: 768px) {
+  body {
+    font-size: 1.125rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  body {
+    font-size: 1.25rem;
+  }
 }
 
 .bg-brand-blue {

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,11 +85,12 @@
   <!-- Content area fills remaining height; only the columns scroll -->
   <main class="flex-1 overflow-hidden">
     <!-- Stack on small screens, side-by-side on lg+ -->
-    <div class="flex h-full flex-col lg:flex-row">
+    <div class="flex h-full flex-col md:flex-row">
 
       <!-- Hooked Column (scrolls) -->
-      <div class="w-full lg:w-1/3 bg-white border-b lg:border-b-0 lg:border-r border-gray-300 overflow-y-auto">
-        <div class="p-4 border-b text-xl font-bold bg-brand-blue text-white">
+      <div :class="['w-full md:w-1/3 bg-white border-t md:border-t-0 md:border-r border-gray-300 overflow-y-auto order-2',
+                    hooked.length > 0 ? 'ring-4 ring-yellow-400 animate-pulse shadow-lg' : '']">
+        <div class="p-4 border-b text-2xl font-bold bg-gradient-to-r from-yellow-400 to-yellow-600 text-blue-900">
           Hooked Up <span v-if="hooked.length > 0">({{ hooked.length }})</span>
         </div>
 
@@ -118,8 +119,8 @@
       </div>
 
       <!-- Event Feed (scrolls) -->
-      <div class="w-full lg:w-2/3 overflow-y-auto event-feed">
-        <div class="p-4 border-b text-xl font-bold flex justify-between items-center bg-brand-blue text-white">
+      <div class="w-full md:w-2/3 overflow-y-auto event-feed order-1">
+        <div class="p-4 border-b text-2xl font-bold flex justify-between items-center bg-gradient-to-r from-brand-blue to-blue-700 text-white">
           Event Feed
         </div>
 


### PR DESCRIPTION
## Summary
- Stack Hooked Up and Event feeds on phones while showing them side-by-side on tablets with the Event Feed leading
- Scale base typography with width-based breakpoints for better readability across devices

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d57b0ad14832ca909c4f433bdab55