### PR TITLE
feat: dynamic tournament theme colors

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,12 +1,21 @@
 @import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700&display=swap');
 
+:root {
+  /* Default brand color; can be overridden dynamically */
+  --brand-color: #002855;
+}
+
 body {
   font-family: 'Barlow', sans-serif;
   touch-action: manipulation;
 }
 
 .bg-brand-blue {
-  background-color: #002855;
+  background-color: var(--brand-color);
+}
+
+.text-brand-blue {
+  color: var(--brand-color);
 }
 
 .text-brand-gold {

--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -135,6 +135,18 @@
       }
     },
     methods: {
+      setBrandColor(t, cfg){
+        let color = cfg?.[t]?.color;
+        if(!color){
+          const key = `t_color_${t}`;
+          color = localStorage.getItem(key);
+          if(!color){
+            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+            localStorage.setItem(key, color);
+          }
+        }
+        document.documentElement.style.setProperty('--brand-color', color);
+      },
       displayEntries(category) {
         const entries = this.groupedLeaderboard[category] || [];
         // Limit to 10 unless Show All is active
@@ -165,6 +177,7 @@
           const configRes = await fetch('https://js9467.github.io/Brtourney/settings.json');
           const allTournaments = await configRes.json();
           this.tournamentLogo = allTournaments[tournament]?.logo || '';
+          this.setBrandColor(tournament, allTournaments);
         } catch(e) { console.error('Logo load failed', e); }
       },
       initLazyLoading() {

--- a/static/participants.html
+++ b/static/participants.html
@@ -128,6 +128,18 @@
       }
     },
     methods: {
+      setBrandColor(t, cfg){
+        let color = cfg?.[t]?.color;
+        if(!color){
+          const key = `t_color_${t}`;
+          color = localStorage.getItem(key);
+          if(!color){
+            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+            localStorage.setItem(key, color);
+          }
+        }
+        document.documentElement.style.setProperty('--brand-color', color);
+      },
       async loadFollowed() {
         try {
           const res = await fetch('/followed-boats');
@@ -179,6 +191,7 @@
           const configRes = await fetch('https://js9467.github.io/Brtourney/settings.json');
           const allTournaments = await configRes.json();
           this.tournamentLogo = allTournaments[tournament]?.logo || '';
+          this.setBrandColor(tournament, allTournaments);
         } catch(e) { console.error('Logo load failed', e); }
       },
       launchKeyboard() { fetch('/launch_keyboard').catch(()=>{}); },

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -218,6 +218,18 @@ createApp({
           this.boatImages = images;
         });
     },
+    setBrandColor(t, cfg){
+      let color = cfg?.[t]?.color;
+      if(!color){
+        const key = `t_color_${t}`;
+        color = localStorage.getItem(key);
+        if(!color){
+          color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+          localStorage.setItem(key, color);
+        }
+      }
+      document.documentElement.style.setProperty('--brand-color', color);
+    },
     loadTournamentLogo() {
       fetch('/api/settings')
         .then(res => res.json())
@@ -225,7 +237,10 @@ createApp({
           const tournament = settings.tournament;
           return fetch('https://js9467.github.io/Brtourney/settings.json')
             .then(res => res.json())
-            .then(all => { this.tournamentLogo = all[tournament]?.logo || ''; });
+            .then(all => {
+              this.tournamentLogo = all[tournament]?.logo || '';
+              this.setBrandColor(tournament, all);
+            });
         });
     },
     formatDate(dateStr) {

--- a/static/settings.html
+++ b/static/settings.html
@@ -287,9 +287,22 @@
         if (file) { this.previewSound(file); this.saveSettings(); }
       },
       onTournamentChange() { this.saveSettings(); this.updateTournamentLogo(); },
+      setBrandColor(t){
+        let color = this.tournaments[t]?.color;
+        if(!color){
+          const key = `t_color_${t}`;
+          color = localStorage.getItem(key);
+          if(!color){
+            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+            localStorage.setItem(key, color);
+          }
+        }
+        document.documentElement.style.setProperty('--brand-color', color);
+      },
       updateTournamentLogo() {
         const t = this.settings.tournament;
         this.tournamentLogo = this.tournaments[t]?.logo || '';
+        this.setBrandColor(t);
       },
       previewSound(file) {
         if (!file) return;

--- a/templates/index.html
+++ b/templates/index.html
@@ -206,6 +206,19 @@ const vm = createApp({
   },
 
   methods:{
+    setBrandColor(t, cfg){
+      let color = cfg?.[t]?.color;
+      if(!color){
+        const key = `t_color_${t}`;
+        color = localStorage.getItem(key);
+        if(!color){
+          color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+          localStorage.setItem(key, color);
+        }
+      }
+      document.documentElement.style.setProperty('--brand-color', color);
+    },
+
     // fetch logo + date (with fallback to /api/tournaments label)
     loadTournamentLogo(){
       fetch('/api/settings')
@@ -217,6 +230,7 @@ const vm = createApp({
             .then(all=>{
               this.tournamentLogo = all[t]?.logo || '';
               this.tournamentDate = all[t]?.dates || '';
+              this.setBrandColor(t, all);
               if(!this.tournamentDate){
                 fetch('/api/tournaments')
                   .then(r=>r.json())


### PR DESCRIPTION
## Summary
- add CSS variable and class for dynamic brand color
- set page themes based on selected tournament or random color

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d597b951c832c94f91ff338f273b8