### PR TITLE
Use tournament logo as boat placeholder

### DIFF
--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -65,8 +65,8 @@
             <!-- Boat Image -->
             <img
               class="lazy w-full h-48 object-cover opacity-0 transition-opacity duration-500"
-              :data-src="entry.image_path ? entry.image_path : '/static/images/boats/default.jpg'"
-              src="/static/images/boats/default.jpg"
+              :data-src="entry.image_path ? entry.image_path : tournamentLogo"
+              :src="tournamentLogo || '/static/images/bigrock.png'"
               loading="lazy"
               alt="Boat Image"
             />

--- a/static/participants.html
+++ b/static/participants.html
@@ -70,9 +70,9 @@
             </div>
             <img
               class="lazy w-full h-48 object-cover opacity-0 transition-opacity duration-500"
-              :data-src="p.image_path || '/static/images/bigrock.png'"
+              :data-src="p.image_path || tournamentLogo"
               :data-uid="p.uid"
-              src="/static/images/bigrock.png"
+              :src="tournamentLogo || '/static/images/bigrock.png'"
               loading="lazy"
               alt="Boat Image"
             />
@@ -191,7 +191,7 @@
           entries.forEach(entry => {
             if (entry.isIntersecting) {
               const img = entry.target;
-              img.src = img.dataset.src || '/static/images/bigrock.png';
+              img.src = img.dataset.src || this.tournamentLogo || '/static/images/bigrock.png';
               img.onload = () => {
                 img.classList.add('opacity-100');
                 const uid = img.getAttribute('data-uid');

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -94,7 +94,7 @@
       <div v-if="drilldownLoading" class="text-gray-500 italic">Loading boat details...</div>
       <div v-else class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         <div v-for="boat in drilldownBoats" :key="boat.uid" class="bg-white rounded shadow p-4 flex flex-col items-center border hover:shadow-lg">
-          <img :src="boat.image" class="w-24 h-24 object-cover rounded mb-2" onerror="this.src='/static/images/boats/default.jpg'"/>
+          <img :src="boat.image || tournamentLogo" class="w-24 h-24 object-cover rounded mb-2" @error="e => e.target.src = tournamentLogo"/>
           <div class="font-bold text-center mb-1">{{ boat.name }}</div>
           <div class="text-sm text-gray-700 text-center leading-tight">
             <div v-for="line in boat.fishLines" :key="line">{{ line }}</div>
@@ -304,7 +304,7 @@ createApp({
       this.drilldownBoats = [];
     },
     getBoatImage(uid) {
-      return this.boatImages[uid] || '/static/images/boats/default.jpg';
+      return this.boatImages[uid] || this.tournamentLogo || '/static/images/bigrock.png';
     },
     extractFishType(details) {
       details = details.toLowerCase();


### PR DESCRIPTION
## Summary
- Serve current tournament logo when boat images are missing
- Show current tournament logo as default boat image in release, participants, and leaderboard views

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d593ffb10832ca8949d279919fd92