### PR TITLE
feat: dynamic tournament theme colors

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,8 @@ from collections import defaultdict
 # ------------------------
 ALERTS_FILE = 'alerts.json'
 NOTIFIED_FILE = 'notified.json'
-MASTER_JSON_URL = "https://js9467.github.io/Brtourney/settings.json"
+# Remote tournament configuration (fallback URL can be overridden via env)
+MASTER_JSON_URL = os.environ.get('MASTER_JSON_URL', 'https://bigrockfishingapp.com/main.json')
 
 SMTP_USER = "bigrockapp@gmail.com"
 SMTP_PASS = "coslxivgfqohjvto"  # Gmail App Password
@@ -90,6 +91,17 @@ def safe_json_dump(path, obj):
     with open(tmp, "w") as f:
         json.dump(obj, f, indent=2)
     os.replace(tmp, path)
+
+def load_master_settings():
+    """Fetch tournament metadata from remote source with graceful fallback."""
+    try:
+        r = requests.get(MASTER_JSON_URL, timeout=10)
+        if r.status_code == 200:
+            return r.json()
+        print(f"⚠️ master settings HTTP {r.status_code} for {MASTER_JSON_URL}")
+    except Exception as e:
+        print(f"⚠️ Failed to fetch master settings: {e}")
+    return {}
 
 def fetch_html(url, use_scraperapi: bool = False) -> str:
     """Fast, resilient HTML fetch with short timeouts."""
@@ -333,9 +345,9 @@ def build_tournaments_index(force: bool = False):
     os.makedirs("cache", exist_ok=True)
     cached = safe_json_load(TOURNAMENTS_CACHE, {}) if not force else {}
     try:
-        master = SESS.get(MASTER_JSON_URL, timeout=15).json()
+        master = load_master_settings()
     except Exception as e:
-        print(f"❌ Failed to fetch MASTER_JSON_URL: {e}")
+        print(f"❌ Failed to load master settings: {e}")
         return cached
     entries = {}
     if isinstance(master, dict):
@@ -465,7 +477,7 @@ def scrape_participants(force: bool = False):
         return safe_json_load(participants_file, [])
 
     try:
-        settings = SESS.get(MASTER_JSON_URL, timeout=12).json()
+        settings = load_master_settings()
         matching_key = next((k for k in settings if k.lower() == tournament.lower()), None)
         if not matching_key:
             raise Exception(f"Tournament '{tournament}' not found in settings.json")
@@ -605,7 +617,7 @@ def scrape_events(force: bool = False, tournament: str | None = None):
         return safe_json_load(events_file, [])
 
     try:
-        remote = SESS.get(MASTER_JSON_URL, timeout=12).json()
+        remote = load_master_settings()
         key = next((k for k in remote if normalize_boat_name(k) == normalize_boat_name(tournament)), None)
         if not key:
             raise Exception(f"Tournament '{tournament}' not found in remote settings.json")
@@ -770,7 +782,7 @@ def scrape_leaderboard(tournament=None, force: bool = False):
         return safe_json_load(lb_file, [])
 
     try:
-        remote = SESS.get(MASTER_JSON_URL, timeout=15).json()
+        remote = load_master_settings()
         key = next((k for k in remote if k.lower() == tournament.lower()), None)
         if not key:
             print(f"❌ Tournament '{tournament}' not found in master JSON.")
@@ -894,6 +906,11 @@ def serve_static(filename):
 @app.route('/healthz')
 def healthz():
     return "ok", 200
+
+@app.route('/main.json')
+def master_settings():
+    """Expose remote tournament settings to the front-end."""
+    return jsonify(load_master_settings())
 
 # ------------------------
 # Routes: scraping & data APIs

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,12 +1,21 @@
 @import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700&display=swap');
 
+:root {
+  /* Default brand color; can be overridden dynamically */
+  --brand-color: #002855;
+}
+
 body {
   font-family: 'Barlow', sans-serif;
   touch-action: manipulation;
 }
 
 .bg-brand-blue {
-  background-color: #002855;
+  background-color: var(--brand-color);
+}
+
+.text-brand-blue {
+  color: var(--brand-color);
 }
 
 .text-brand-gold {
@@ -25,4 +34,78 @@ button:hover {
   padding: 1rem;
   font-style: italic;
   color: #666;
+}
+
+[v-cloak] {
+  display: none;
+}
+
+.toast {
+  position: fixed;
+  top: 5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+  font-weight: 600;
+  color: black;
+  text-align: center;
+  max-width: 90vw;
+}
+
+.modal-bg {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+@keyframes marquee {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+.message-strip-wrapper {
+  position: relative;
+  overflow: hidden;
+  height: 2.25rem;
+  background-color: var(--brand-color);
+}
+
+.message-strip {
+  display: inline-block;
+  white-space: nowrap;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: white;
+  animation: marquee 40s linear infinite;
+  will-change: transform;
+  padding-left: 100%;
+}
+
+.message-strip a {
+  color: #facc15;
+  text-decoration: underline;
+  font-weight: bold;
+  padding: 0 0.5rem;
+}
+
+.message-strip-wrapper:hover .message-strip {
+  animation-play-state: paused;
+  cursor: pointer;
+}
+
+@keyframes pulse-slow {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+.animate-pulse-slow {
+  animation: pulse-slow 3s ease-in-out infinite;
 }

--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -135,6 +135,25 @@
       }
     },
     methods: {
+      setBrandColor(t, cfg){
+        let color = cfg?.[t]?.color;
+        const key = `t_color_${t}`;
+        if(!color){
+          if(t === 'Big Rock'){
+            localStorage.removeItem(key);
+            color = '#002855';
+          } else {
+            color = localStorage.getItem(key);
+            if(!color){
+              color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+              localStorage.setItem(key, color);
+            }
+          }
+        } else if(t === 'Big Rock'){
+          localStorage.removeItem(key);
+        }
+        document.documentElement.style.setProperty('--brand-color', color);
+      },
       displayEntries(category) {
         const entries = this.groupedLeaderboard[category] || [];
         // Limit to 10 unless Show All is active
@@ -162,9 +181,10 @@
           const settingsRes = await fetch('/api/settings');
           const settings = await settingsRes.json();
           const tournament = settings.tournament;
-          const configRes = await fetch('https://js9467.github.io/Brtourney/settings.json');
+          const configRes = await fetch('/main.json');
           const allTournaments = await configRes.json();
           this.tournamentLogo = allTournaments[tournament]?.logo || '';
+          this.setBrandColor(tournament, allTournaments);
         } catch(e) { console.error('Logo load failed', e); }
       },
       initLazyLoading() {
@@ -191,6 +211,5 @@
   app.mount('#app');
   </script>
 
-  <style>[v-cloak]{display:none}</style>
 </body>
 </html>

--- a/static/participants.html
+++ b/static/participants.html
@@ -7,7 +7,6 @@
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/static/css/base.css" />
-  <style>[v-cloak]{display:none}</style>
 </head>
 <body class="bg-gray-100 text-gray-800 font-sans overflow-y-auto">
   <div id="app" v-cloak>
@@ -128,6 +127,25 @@
       }
     },
     methods: {
+      setBrandColor(t, cfg){
+        let color = cfg?.[t]?.color;
+        const key = `t_color_${t}`;
+        if(!color){
+          if(t === 'Big Rock'){
+            localStorage.removeItem(key);
+            color = '#002855';
+          } else {
+            color = localStorage.getItem(key);
+            if(!color){
+              color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+              localStorage.setItem(key, color);
+            }
+          }
+        } else if(t === 'Big Rock'){
+          localStorage.removeItem(key);
+        }
+        document.documentElement.style.setProperty('--brand-color', color);
+      },
       async loadFollowed() {
         try {
           const res = await fetch('/followed-boats');
@@ -176,9 +194,10 @@
           const settingsRes = await fetch('/api/settings');
           const settings = await settingsRes.json();
           const tournament = settings.tournament;
-          const configRes = await fetch('https://js9467.github.io/Brtourney/settings.json');
+          const configRes = await fetch('/main.json');
           const allTournaments = await configRes.json();
           this.tournamentLogo = allTournaments[tournament]?.logo || '';
+          this.setBrandColor(tournament, allTournaments);
         } catch(e) { console.error('Logo load failed', e); }
       },
       launchKeyboard() { fetch('/launch_keyboard').catch(()=>{}); },

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -8,9 +8,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link rel="stylesheet" href="/static/css/base.css">
-  <style>
-    .modal-bg { background-color: rgba(0, 0, 0, 0.6); }
-  </style>
+  
 </head>
 <body class="bg-gray-100 text-gray-800 font-sans overflow-y-auto">
 <div id="app">
@@ -218,14 +216,36 @@ createApp({
           this.boatImages = images;
         });
     },
+    setBrandColor(t, cfg){
+      let color = cfg?.[t]?.color;
+      const key = `t_color_${t}`;
+      if(!color){
+        if(t === 'Big Rock'){
+          localStorage.removeItem(key);
+          color = '#002855';
+        } else {
+          color = localStorage.getItem(key);
+          if(!color){
+            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+            localStorage.setItem(key, color);
+          }
+        }
+      } else if(t === 'Big Rock'){
+        localStorage.removeItem(key);
+      }
+      document.documentElement.style.setProperty('--brand-color', color);
+    },
     loadTournamentLogo() {
       fetch('/api/settings')
         .then(res => res.json())
         .then(settings => {
           const tournament = settings.tournament;
-          return fetch('https://js9467.github.io/Brtourney/settings.json')
+          return fetch('/main.json')
             .then(res => res.json())
-            .then(all => { this.tournamentLogo = all[tournament]?.logo || ''; });
+            .then(all => {
+              this.tournamentLogo = all[tournament]?.logo || '';
+              this.setBrandColor(tournament, all);
+            });
         });
     },
     formatDate(dateStr) {

--- a/static/settings.html
+++ b/static/settings.html
@@ -8,22 +8,6 @@
   <script src="https://cdn.jsdelivr.net/npm/axios@1.6.8/dist/axios.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/static/css/base.css">
-  <style>
-    body { touch-action: manipulation; }
-    .toast {
-      position: fixed;
-      top: 5rem;
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 9999;
-      padding: 0.75rem 1rem;
-      border-radius: 0.375rem;
-      font-weight: 600;
-      color: black;
-      text-align: center;
-      max-width: 90vw;
-    }
-  </style>
 </head>
 <body class="bg-gray-100 text-gray-900 font-sans overflow-y-auto">
   <div id="app">
@@ -287,9 +271,29 @@
         if (file) { this.previewSound(file); this.saveSettings(); }
       },
       onTournamentChange() { this.saveSettings(); this.updateTournamentLogo(); },
+      setBrandColor(t){
+        let color = this.tournaments[t]?.color;
+        const key = `t_color_${t}`;
+        if(!color){
+          if(t === 'Big Rock'){
+            localStorage.removeItem(key);
+            color = '#002855';
+          } else {
+            color = localStorage.getItem(key);
+            if(!color){
+              color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+              localStorage.setItem(key, color);
+            }
+          }
+        } else if(t === 'Big Rock'){
+          localStorage.removeItem(key);
+        }
+        document.documentElement.style.setProperty('--brand-color', color);
+      },
       updateTournamentLogo() {
         const t = this.settings.tournament;
         this.tournamentLogo = this.tournaments[t]?.logo || '';
+        this.setBrandColor(t);
       },
       previewSound(file) {
         if (!file) return;
@@ -347,7 +351,7 @@
         if (storedVol) this.settings.event_volume = parseInt(storedVol, 10);
 
         // Load tournaments JSON (logos/streams)
-        axios.get('https://js9467.github.io/Brtourney/settings.json').then(res2 => {
+        axios.get('/main.json').then(res2 => {
           this.fallbackStream = res2.data?.fallback_stream || '';
 
           const entries = Object.entries(res2.data || {});

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,18 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
   <link rel="stylesheet" href="/static/css/base.css">
 
-  <style>
-    @keyframes marquee { 0% { transform: translateX(100%); } 100% { transform: translateX(-100%); } }
-    .message-strip-wrapper { position: relative; overflow: hidden; height: 2.25rem; background-color: #002855; }
-    .message-strip {
-      display: inline-block; white-space: nowrap; font-size: 1.2rem; font-weight: 600; color: white;
-      animation: marquee 40s linear infinite; will-change: transform; padding-left: 100%;
-    }
-    .message-strip a { color: #facc15; text-decoration: underline; font-weight: bold; padding: 0 0.5rem; }
-    .message-strip-wrapper:hover .message-strip { animation-play-state: paused; cursor: pointer; }
-    @keyframes pulse-slow { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
-    .animate-pulse-slow { animation: pulse-slow 3s ease-in-out infinite; }
-  </style>
+  
 </head>
 
 <body class="bg-gray-100 text-gray-900 font-sans h-screen overflow-x-hidden">
@@ -206,17 +195,38 @@ const vm = createApp({
   },
 
   methods:{
+    setBrandColor(t, cfg){
+      let color = cfg?.[t]?.color;
+      const key = `t_color_${t}`;
+      if(!color){
+        if(t === 'Big Rock'){
+          localStorage.removeItem(key);
+          color = '#002855';
+        } else {
+          color = localStorage.getItem(key);
+          if(!color){
+            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
+            localStorage.setItem(key, color);
+          }
+        }
+      } else if(t === 'Big Rock'){
+        localStorage.removeItem(key);
+      }
+      document.documentElement.style.setProperty('--brand-color', color);
+    },
+
     // fetch logo + date (with fallback to /api/tournaments label)
     loadTournamentLogo(){
       fetch('/api/settings')
         .then(r=>r.json())
         .then(s=>{
           const t=s.tournament;
-          fetch('https://js9467.github.io/Brtourney/settings.json')
+          fetch('/main.json')
             .then(r=>r.json())
             .then(all=>{
               this.tournamentLogo = all[t]?.logo || '';
               this.tournamentDate = all[t]?.dates || '';
+              this.setBrandColor(t, all);
               if(!this.tournamentDate){
                 fetch('/api/tournaments')
                   .then(r=>r.json())
@@ -271,7 +281,7 @@ const vm = createApp({
       else{
         fetch('/api/settings').then(r=>r.json()).then(s=>{
           const t=s.tournament;
-          fetch('https://js9467.github.io/Brtourney/settings.json').then(r=>r.json()).then(all=>{
+          fetch('/main.json').then(r=>r.json()).then(all=>{
             const stream=all[t]?.stream||all[t]?.fallback_stream;
             if(stream){
               if(Hls.isSupported()){


### PR DESCRIPTION
## Summary
- load tournament settings from a remote source and serve them via `/main.json`
- update pages to fetch remote config and preserve Big Rock's blue theme while randomizing others

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d597b951c832c94f91ff338f273b8