### PR TITLE
Expose full release events in summary endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1580,7 +1580,8 @@ def release_summary_data():
             summary[day]["total_releases"] += 1
 
         result = [{"date": k, **v} for k, v in sorted(summary.items(), key=lambda x: x[0], reverse=True)]
-        return jsonify({"status": "ok", "demo_mode": demo_mode, "summary": result})
+        return jsonify({"status": "ok", "demo_mode": demo_mode,
+                        "summary": result, "events": events})
     except Exception as e:
         print(f"❌ Error generating release summary: {e}")
         return jsonify({"status": "error", "message": str(e)})

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -138,9 +138,7 @@ createApp({
         const summaryData = await fetch('/release-summary-data').then(r=>r.json());
         this.summary = summaryData.summary || [];
         this.demoMode = summaryData.demo_mode || false;
-
-        const eventsData = await fetch('/scrape/events').then(r=>r.json());
-        this.allEvents = eventsData.events || [];
+        this.allEvents = summaryData.events || [];
 
         if (this.demoMode) {
           this.fabricateDemoData();


### PR DESCRIPTION
## Summary
- Include full release event list in `/release-summary-data` JSON response
- Frontend loads events from summary response instead of extra request

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689deb1c6638832ca4524147079b919c