### PR TITLE
Normalize demo event timestamps in demo mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -963,21 +963,19 @@ def scrape_events_route():
 
         now = datetime.now()
         today = now.date()
-        day_filter = request.args.get("day")
 
         filtered = []
         for e in all_events:
             try:
-                ts = date_parser.parse(e["timestamp"])
-
+                original_ts = date_parser.parse(e["timestamp"])
+                ts = datetime.combine(today, original_ts.time())
             except Exception:
                 continue
-            if day_filter:
-                if ts.date() == today and ts <= now:
-                    filtered.append(e)
-            else:
-                if ts <= now:
-                    filtered.append(e)
+
+            if ts <= now:
+                adjusted = dict(e)
+                adjusted["timestamp"] = ts.isoformat()
+                filtered.append(adjusted)
 
         filtered.sort(key=lambda e: e["timestamp"], reverse=True)
 


### PR DESCRIPTION
## Summary
- Normalize demo event timestamps to today's date before filtering
- Filter out events scheduled later today so resolutions appear at the correct time

## Testing
- `python -m py_compile app.py`
- `pip install flask` *(fails: Could not connect to proxy)*
- `pip install python-dateutil` *(fails: Could not connect to proxy)*
- `python - <<'PY'
import json
from datetime import datetime

with open('demo_data.json','w') as f: ... # (manual test script verifying event ordering)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e06877d90832ca07c1b5f5433699b