### PR TITLE
Show dates in live event feed

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -115,7 +115,7 @@
 
           <div class="flex-1">
             <div class="text-lg font-semibold">{{ event.boat }}</div>
-            <div class="text-sm text-gray-600">Hooked Up at {{ formatTime(event.timestamp) }}</div>
+            <div class="text-sm text-gray-600">Hooked Up on {{ formatDate(event.timestamp) }} at {{ formatTime(event.timestamp) }}</div>
           </div>
 
           <button @click="toggleFollow(event.boat)"
@@ -158,7 +158,7 @@
 
           <div class="flex-1">
             <div class="text-lg font-semibold">{{ event.boat }}</div>
-            <div class="text-sm text-gray-600">{{ event.event }} — {{ formatTime(event.timestamp) }}</div>
+            <div class="text-sm text-gray-600">{{ event.event }} — {{ formatDate(event.timestamp) }} at {{ formatTime(event.timestamp) }}</div>
             <div class="text-sm">{{ event.details }}</div>
           </div>
 
@@ -286,7 +286,22 @@ const vm = createApp({
     loadParticipants(){fetch('/participants_data').then(r=>r.json()).then(d=>{const imgs={...this.boatImages};for(const p of d.participants)imgs[p.uid]=p.image_path;imgs['palmer_lou']='/static/images/palmer_lou.jpg';this.boatImages=imgs;});},
     getBoatImage(uid){return this.boatImages[uid]||'/static/images/bigrock.webp';},
     onImageError(e){e.target.src='/static/images/bigrock.webp';},
-    formatTime(ts){const dt=new Date(ts);return dt.toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',hour12:true});},
+    parseTs(ts){
+      if(!ts) return null;
+      let dt;
+      if(typeof ts==='number'){
+        dt=ts.toString().length===10?new Date(ts*1000):new Date(ts);
+      }else if(typeof ts==='string' && /^\d+$/.test(ts)){
+        const num=Number(ts);
+        dt=ts.length===10?new Date(num*1000):new Date(num);
+      }else{
+        dt=new Date(ts);
+        if(isNaN(dt))dt=new Date(String(ts).replace(' ','T'));
+      }
+      return isNaN(dt)?null:dt;
+    },
+    formatTime(ts){const dt=this.parseTs(ts);return dt?dt.toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',hour12:true}):'';},
+    formatDate(ts){const dt=this.parseTs(ts);return dt?dt.toLocaleDateString('en-US',{month:'numeric',day:'numeric'}):'';},
     applyRadioVolume(){const p=document.getElementById('radio-player');if(p)p.volume=this.settings.radio_volume/100;},
     toggleRadio(){
       const p=document.getElementById('radio-player');if(!p)return;


### PR DESCRIPTION
## Summary
- handle numeric or string timestamps when rendering event details
- show event date reliably in live "Hooked Up" and event feed rows

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e52912f7c832c82f9242b8c1bb929