### PR TITLE
Ensure hooked events panel visible on all screens

### DIFF
--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -136,15 +136,7 @@
     },
     methods: {
       setBrandColor(t, cfg){
-        let color = cfg?.[t]?.color;
-        if(!color){
-          const key = `t_color_${t}`;
-          color = localStorage.getItem(key);
-          if(!color){
-            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
-            localStorage.setItem(key, color);
-          }
-        }
+        const color = cfg?.[t]?.color || '#002855';
         document.documentElement.style.setProperty('--brand-color', color);
       },
       displayEntries(category) {

--- a/static/participants.html
+++ b/static/participants.html
@@ -129,15 +129,7 @@
     },
     methods: {
       setBrandColor(t, cfg){
-        let color = cfg?.[t]?.color;
-        if(!color){
-          const key = `t_color_${t}`;
-          color = localStorage.getItem(key);
-          if(!color){
-            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
-            localStorage.setItem(key, color);
-          }
-        }
+        const color = cfg?.[t]?.color || '#002855';
         document.documentElement.style.setProperty('--brand-color', color);
       },
       async loadFollowed() {

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -217,15 +217,7 @@ createApp({
         });
     },
     setBrandColor(t, cfg){
-      let color = cfg?.[t]?.color;
-      if(!color){
-        const key = `t_color_${t}`;
-        color = localStorage.getItem(key);
-        if(!color){
-          color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
-          localStorage.setItem(key, color);
-        }
-      }
+      const color = cfg?.[t]?.color || '#002855';
       document.documentElement.style.setProperty('--brand-color', color);
     },
     loadTournamentLogo() {

--- a/static/settings.html
+++ b/static/settings.html
@@ -288,15 +288,7 @@
       },
       onTournamentChange() { this.saveSettings(); this.updateTournamentLogo(); },
       setBrandColor(t){
-        let color = this.tournaments[t]?.color;
-        if(!color){
-          const key = `t_color_${t}`;
-          color = localStorage.getItem(key);
-          if(!color){
-            color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
-            localStorage.setItem(key, color);
-          }
-        }
+        const color = this.tournaments[t]?.color || '#002855';
         document.documentElement.style.setProperty('--brand-color', color);
       },
       updateTournamentLogo() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,14 +20,6 @@
     .message-strip-wrapper:hover .message-strip { animation-play-state: paused; cursor: pointer; }
     @keyframes pulse-slow { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
     .animate-pulse-slow { animation: pulse-slow 3s ease-in-out infinite; }
-    /* Force side-by-side layout on small screens when in landscape orientation */
-    @media (orientation: landscape) and (max-width: 767px) {
-      .mobile-landscape-row { flex-direction: row; }
-
-      .mobile-landscape-row .events-col { width: 60%; }
-      .mobile-landscape-row .hooked-col { width: 40%; }
-
-    }
   </style>
 </head>
 
@@ -90,13 +82,13 @@
     <div class="absolute bottom-1 right-3 text-xs text-white/50 italic" v-if="version">v{{ version }}</div>
   </header>
 
-  <!-- Content area fills remaining height; only the columns scroll -->
+  <!-- Content area fills remaining height; both columns scroll -->
   <main class="flex-1 overflow-hidden">
-    <!-- Stack on small screens, side-by-side on lg+ -->
-    <div class="flex h-full flex-col md:flex-row mobile-landscape-row">
+    <!-- Always display columns side by side -->
+    <div class="flex h-full flex-row">
 
       <!-- Hooked Column (scrolls) -->
-      <div class="hooked-col" :class="['w-full md:w-1/3 bg-white border-t md:border-t-0 md:border-r border-gray-300 overflow-y-auto order-2',
+      <div class="hooked-col" :class="['w-1/4 bg-white border-l border-gray-300 overflow-y-auto order-2',
                     hooked.length > 0 ? 'ring-4 ring-yellow-400 animate-pulse shadow-lg' : '']">
         <div class="p-4 border-b text-2xl font-bold bg-gradient-to-r from-yellow-400 to-yellow-600 text-blue-900">
           Hooked Up <span v-if="hooked.length > 0">({{ hooked.length }})</span>
@@ -127,8 +119,8 @@
       </div>
 
       <!-- Event Feed (scrolls) -->
-      <div class="w-full md:w-2/3 overflow-y-auto event-feed order-1 events-col">
-        <div class="p-4 border-b text-2xl font-bold flex justify-between items-center bg-gradient-to-r from-brand-blue to-blue-700 text-white">
+      <div class="w-3/4 overflow-y-auto event-feed order-1 events-col border-r border-gray-300">
+        <div class="p-4 border-b text-2xl font-bold flex justify-between items-center bg-gradient-to-r from-yellow-400 to-yellow-600 text-blue-900">
           Event Feed
         </div>
 
@@ -216,15 +208,7 @@ const vm = createApp({
 
   methods:{
     setBrandColor(t, cfg){
-      let color = cfg?.[t]?.color;
-      if(!color){
-        const key = `t_color_${t}`;
-        color = localStorage.getItem(key);
-        if(!color){
-          color = `#${Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0')}`;
-          localStorage.setItem(key, color);
-        }
-      }
+      const color = cfg?.[t]?.color || '#002855';
       document.documentElement.style.setProperty('--brand-color', color);
     },
 


### PR DESCRIPTION
## Summary
- Always display the event feed and hooked list side by side
- Allocate more space to the event feed for better readability
- Use official Big Rock blue across all views for consistent branding
- Style the Event Feed header to match the Hooked panel

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e6ecd07f4832c9b3a59eace1764c8