### PR TITLE
Ensure on-screen keyboard triggers for text fields

### DIFF
--- a/static/participants.html
+++ b/static/participants.html
@@ -186,8 +186,12 @@
           this.setBrandColor(tournament, allTournaments);
         } catch(e) { console.error('Logo load failed', e); }
       },
-      launchKeyboard() { fetch('/launch_keyboard').catch(()=>{}); },
-      hideKeyboard() { fetch('/hide_keyboard').catch(()=>{}); },
+      launchKeyboard() {
+        fetch('/launch_keyboard', { method: 'POST' }).catch(() => {});
+      },
+      hideKeyboard() {
+        fetch('/hide_keyboard', { method: 'POST' }).catch(() => {});
+      },
 
       initLazyLoading() {
         const images = document.querySelectorAll('img.lazy');

--- a/static/settings.html
+++ b/static/settings.html
@@ -105,7 +105,8 @@
         <div v-for="(recipient, index) in recipients" :key="index" class="mb-3 border-b pb-3">
           <label class="block mb-1">Email Address:</label>
           <input type="email" v-model="recipient.email" placeholder="name@example.com"
-                 class="border px-2 py-1 rounded w-full mb-2" />
+                 class="border px-2 py-1 rounded w-full mb-2"
+                 @focus="launchKeyboard" @blur="hideKeyboard" />
           <button v-if="recipients.length > 1"
                   @click="removeRecipient(index)"
                   class="text-red-600 mt-1 text-sm hover:underline">
@@ -257,6 +258,12 @@
       },
       addRecipient() { this.recipients.push({ email: '' }); },
       removeRecipient(index) { this.recipients.splice(index, 1); },
+      launchKeyboard() {
+        fetch('/launch_keyboard', { method: 'POST' }).catch(() => {});
+      },
+      hideKeyboard() {
+        fetch('/hide_keyboard', { method: 'POST' }).catch(() => {});
+      },
       saveAlerts() {
         const emails = this.recipients
           .filter(r => r.email.trim())
@@ -306,7 +313,9 @@
         axios.get('/wifi/scan').then(res => { this.wifiNetworks = res.data.networks; });
       },
       connectWifi(ssid) {
+        fetch('/launch_keyboard', { method: 'POST' }).catch(() => {});
         const password = prompt(`Password for ${ssid} (leave blank if open)`, '');
+        fetch('/hide_keyboard', { method: 'POST' }).catch(() => {});
         axios.post('/wifi/connect', { ssid, password }).then(() => {
           this.showToast(`Connecting to ${ssid}`, 'success');
           this.fetchWifi();

--- a/static/wifi.html
+++ b/static/wifi.html
@@ -17,19 +17,29 @@
             <button type="submit">Connect</button>
         </form>
     </div>
-    <script>
-        document.getElementById('wifi-form').addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const formData = new FormData(e.target);
-            const response = await fetch('/wifi', {
-                method: 'POST',
-                body: formData
-            });
-            const result = await response.json();
-            if (result.status === 'success') {
-                alert('Connecting to Wi-Fi... Please wait.');
-            }
-        });
-    </script>
+      <script>
+          const ssidInput = document.getElementById('ssid');
+          const passwordInput = document.getElementById('password');
+          [ssidInput, passwordInput].forEach(inp => {
+              inp.addEventListener('focus', () => {
+                  fetch('/launch_keyboard', { method: 'POST' }).catch(() => {});
+              });
+              inp.addEventListener('blur', () => {
+                  fetch('/hide_keyboard', { method: 'POST' }).catch(() => {});
+              });
+          });
+          document.getElementById('wifi-form').addEventListener('submit', async (e) => {
+              e.preventDefault();
+              const formData = new FormData(e.target);
+              const response = await fetch('/wifi', {
+                  method: 'POST',
+                  body: formData
+              });
+              const result = await response.json();
+              if (result.status === 'success') {
+                  alert('Connecting to Wi-Fi... Please wait.');
+              }
+          });
+      </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure launch/hide keyboard endpoints are called with POST on participants page
- Wire up settings page email inputs and Wi-Fi prompt to control on-screen keyboard
- Add keyboard show/hide handlers to Wi-Fi setup form

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e751753dc832c936c103305d730f0