### PR TITLE
Enable WAV files for followed and boated sounds

### DIFF
--- a/app.py
+++ b/app.py
@@ -1612,7 +1612,11 @@ def hide_keyboard():
 def list_sounds():
     sound_dir = os.path.join('static', 'sounds')
     try:
-        files = [f for f in os.listdir(sound_dir) if f.lower().endswith('.mp3')]
+        files = [
+            f
+            for f in os.listdir(sound_dir)
+            if f.lower().endswith(('.mp3', '.wav'))
+        ]
         return jsonify({'files': files})
     except Exception as e:
         return jsonify({'files': [], 'error': str(e)}), 500

--- a/static/settings.html
+++ b/static/settings.html
@@ -81,7 +81,7 @@
         <label class="block font-semibold mb-1">Sound for Followed Boat Activity</label>
         <select v-model="settings.followed_sound" @change="onFollowedSoundChange" class="w-full p-2 rounded border border-gray-400 bg-white text-black">
           <option disabled value="">-- Select Sound --</option>
-          <option v-for="file in availableSounds" :key="file" :value="file">{{ file }}</option>
+          <option v-for="file in availableSounds" :key="file" :value="file">{{ file.replace(/\.[^.]+$/, '') }}</option>
         </select>
       </div>
 
@@ -89,7 +89,7 @@
         <label class="block font-semibold mb-1">Sound for Any "Boated" Event</label>
         <select v-model="settings.boated_sound" @change="onBoatedSoundChange" class="w-full p-2 rounded border border-gray-400 bg-white text-black">
           <option disabled value="">-- Select Sound --</option>
-          <option v-for="file in availableSounds" :key="file" :value="file">{{ file }}</option>
+          <option v-for="file in availableSounds" :key="file" :value="file">{{ file.replace(/\.[^.]+$/, '') }}</option>
         </select>
       </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -252,7 +252,14 @@ const vm = createApp({
         .replace(/^_+|_+$/g,'');
       return this.followed.some(b=>norm(b)===norm(uid));
     },
-    playSound(f){if(!f||!this.settings.sounds_enabled)return;let fn=f.trim();if(!fn.toLowerCase().endsWith('.mp3'))fn+='.mp3';const a=new Audio(`/static/sounds/${encodeURIComponent(fn)}`);a.volume=(this.settings.event_volume||80)/100;a.play().catch(()=>{});},
+    playSound(f){
+      if(!f||!this.settings.sounds_enabled)return;
+      let fn=f.trim();
+      if(!fn.toLowerCase().match(/\.(mp3|wav)$/))fn+='.mp3';
+      const a=new Audio(`/static/sounds/${encodeURIComponent(fn)}`);
+      a.volume=(this.settings.event_volume||80)/100;
+      a.play().catch(()=>{});
+    },
 
     fetchAll(){
       this.loading=true;


### PR DESCRIPTION
## Summary
- Allow sound listing and playback to include `.wav` files
- Hide file extensions for available sound options in settings
- Support `.wav` and `.mp3` extensions when playing event sounds

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e9300e920832caaff0d5da15cf268