### PR TITLE
Implement Bluetooth scanning via bluetoothctl

### DIFF
--- a/app.py
+++ b/app.py
@@ -1457,17 +1457,117 @@ def scrape_tournament_dates():
 # ------------------------
 @app.route('/bluetooth/status')
 def bluetooth_status():
-    return jsonify({"enabled": True})
+    try:
+        out = subprocess.check_output(['bluetoothctl', 'show'], text=True)
+        enabled = 'Powered: yes' in out
+        connected_devices = []
+        try:
+            devices_out = subprocess.check_output(
+                ['bluetoothctl', 'devices', 'Connected'], text=True
+            )
+            for line in devices_out.splitlines():
+                if line.startswith('Device '):
+                    parts = line.split(' ', 2)
+                    if len(parts) >= 3:
+                        connected_devices.append({
+                            "mac": parts[1],
+                            "name": parts[2]
+                        })
+        except Exception:
+            pass
+        return jsonify({
+            "enabled": enabled,
+            "connected": bool(connected_devices),
+            "devices": connected_devices
+        })
+    except Exception as e:
+        return jsonify({"enabled": False, "connected": False, "devices": [], "error": str(e)}), 500
 
 @app.route('/bluetooth/scan')
 def bluetooth_scan():
-    return jsonify({"devices": [{"name": "Test Device", "mac": "00:11:22:33:44:55", "connected": False}]})
+    try:
+        # Start a timed scan for nearby devices
+        subprocess.run(
+            ['bluetoothctl', 'scan', 'on'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(5)
+        subprocess.run(
+            ['bluetoothctl', 'scan', 'off'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        # Collect discovered devices
+        devices_out = subprocess.check_output(
+            ['bluetoothctl', 'devices'], text=True
+        )
+        devices = []
+        for line in devices_out.splitlines():
+            if line.startswith('Device '):
+                parts = line.split(' ', 2)
+                if len(parts) >= 3:
+                    mac, name = parts[1], parts[2]
+                    try:
+                        info = subprocess.check_output(
+                            ['bluetoothctl', 'info', mac], text=True
+                        )
+                        paired = 'Paired: yes' in info
+                        connected = 'Connected: yes' in info
+                    except Exception:
+                        paired = False
+                        connected = False
+                    if not connected:
+                        devices.append({
+                            "name": name,
+                            "mac": mac,
+                            "paired": paired,
+                            "connected": connected,
+                        })
+        return jsonify({"devices": devices})
+    except Exception as e:
+        return jsonify({"devices": [], "error": str(e)}), 500
 
 @app.route('/bluetooth/connect', methods=['POST'])
 def bluetooth_connect():
-    data = request.get_json()
-    print(f"Connecting to: {data.get('mac')}")
-    return jsonify({"status": "ok"})
+    data = request.get_json() or {}
+    mac = data.get('mac')
+    if not mac:
+        return jsonify({"status": "error", "message": "Missing 'mac'"}), 400
+    try:
+        try:
+            subprocess.check_output(
+                ['bluetoothctl', 'connect', mac],
+                text=True,
+                stderr=subprocess.STDOUT,
+            )
+        except subprocess.CalledProcessError:
+            try:
+                subprocess.check_output(
+                    ['bluetoothctl', 'pair', mac],
+                    text=True,
+                    stderr=subprocess.STDOUT,
+                )
+                subprocess.check_output(
+                    ['bluetoothctl', 'connect', mac],
+                    text=True,
+                    stderr=subprocess.STDOUT,
+                )
+            except subprocess.CalledProcessError as e:
+                return jsonify({"status": "error", "message": e.output.strip()}), 500
+
+        info = subprocess.check_output(['bluetoothctl', 'info', mac], text=True)
+        connected = 'Connected: yes' in info
+        name_line = next((l for l in info.splitlines() if l.strip().startswith('Name:')), None)
+        name = name_line.split('Name:', 1)[1].strip() if name_line else None
+        return jsonify({
+            "status": "ok" if connected else "error",
+            "connected": connected,
+            "device": {"mac": mac, "name": name},
+        })
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
 
 @app.route('/wifi/scan')
 def wifi_scan():


### PR DESCRIPTION
## Summary
- Replace Bluetooth stubs with real `bluetoothctl` calls to report adapter power status
- Perform a timed scan, parse discovered devices, and expose their paired and connection state
- Attempt device pairing if `connect` fails and return device info after connecting
- Filter scan results to only list devices that are not already connected

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e8fb97d10832caa4f67ae3ba49d07