### PR TITLE
Add offline splash page for Wi-Fi connection

### DIFF
--- a/app.py
+++ b/app.py
@@ -925,6 +925,10 @@ def scrape_leaderboard(tournament=None, force: bool = False):
 def homepage():
     return send_from_directory('templates', 'index.html')
 
+@app.route('/offline')
+def offline_page():
+    return send_from_directory('templates', 'offline.html')
+
 @app.route('/participants')
 def participants_page():
     return send_from_directory('static', 'participants.html')

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Events Feed</title>
+  <script>
+    function goOffline() {
+      window.location.href = '/offline';
+    }
+    if (!navigator.onLine) {
+      goOffline();
+    } else {
+      window.addEventListener('offline', goOffline);
+    }
+  </script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>

--- a/templates/offline.html
+++ b/templates/offline.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Connect to Wi-Fi</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 2rem; background: #f7f7f7; }
+    h1 { color: #333; }
+    #networks > div { margin: 0.5rem 0; }
+    button { padding: 0.4rem 0.8rem; margin-left: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Offline</h1>
+  <p>No network connection detected. Select a Wi-Fi network to connect.</p>
+  <div id="networks">Scanning...</div>
+  <div id="status"></div>
+  <script>
+    async function scan() {
+      try {
+        const res = await fetch('/wifi/scan');
+        const data = await res.json();
+        const container = document.getElementById('networks');
+        container.innerHTML = '';
+        if (!data.networks || data.networks.length === 0) {
+          container.textContent = 'No networks found.';
+          return;
+        }
+        data.networks.forEach(net => {
+          const row = document.createElement('div');
+          row.textContent = `${net.ssid} (${net.signal}%)`;
+          const btn = document.createElement('button');
+          if (net.connected) {
+            btn.textContent = 'Connected';
+            btn.disabled = true;
+          } else {
+            btn.textContent = 'Connect';
+            btn.onclick = () => connect(net.ssid);
+          }
+          row.appendChild(btn);
+          container.appendChild(row);
+        });
+      } catch (e) {
+        document.getElementById('networks').textContent = 'Scan failed.';
+      }
+    }
+    async function connect(ssid) {
+      const password = prompt('Password for ' + ssid + ' (leave blank if open):', '');
+      const res = await fetch('/wifi/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ssid, password: password || '' })
+      });
+      const data = await res.json();
+      document.getElementById('status').textContent = data.message || data.status;
+      if (data.status === 'ok') {
+        setTimeout(() => window.location.replace('/'), 2000);
+      }
+    }
+    window.addEventListener('online', () => window.location.replace('/'));
+    scan();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Redirect to new offline page when no network is detected
- Offline page lets users scan and connect to Wi-Fi then returns to main feed

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e972d793c832c81878e6c41431db2