### PR TITLE
Serve frontend assets locally with offline check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+__pycache__/

--- a/app.py
+++ b/app.py
@@ -925,6 +925,10 @@ def scrape_leaderboard(tournament=None, force: bool = False):
 def homepage():
     return send_from_directory('templates', 'index.html')
 
+@app.route('/offline')
+def offline_page():
+    return send_from_directory('templates', 'offline.html')
+
 @app.route('/participants')
 def participants_page():
     return send_from_directory('static', 'participants.html')

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bigrock-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "hls.js": "^1.6.10",
+    "vue": "^3.5.18"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.21",
+    "esbuild": "^0.25.9",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/input.css
+++ b/src/input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import Hls from 'hls.js';
+
+window.Vue = { createApp };
+window.Hls = Hls;

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -1,0 +1,1 @@
+/* Placeholder Tailwind CSS. Run 'npx tailwindcss -i ./src/input.css -o ./static/css/tailwind.css --minify' to generate real styles. */

--- a/static/js/bundle.js
+++ b/static/js/bundle.js
@@ -1,0 +1,8 @@
+// Placeholder bundle for offline use. Run 'npx esbuild src/main.js --bundle --minify --outfile=static/js/bundle.js'
+// to generate a full bundle including Vue and HLS.js.
+window.Vue = {
+  createApp() {
+    return { mount() {} };
+  }
+};
+window.Hls = function(){};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./templates/**/*.html", "./static/**/*.html", "./src/**/*.js"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Events Feed</title>
-  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <script>
+    async function ensureOnline() {
+      if (!navigator.onLine) return location.replace('/offline');
+      try {
+        await fetch('/', { method: 'HEAD', cache: 'no-store' });
+      } catch (e) {
+        return location.replace('/offline');
+      }
+      window.addEventListener('offline', () => location.replace('/offline'));
+    }
+    ensureOnline();
+  </script>
   <link rel="stylesheet" href="/static/css/base.css">
+  <link rel="stylesheet" href="/static/css/tailwind.css">
+  <script src="/static/js/bundle.js" defer></script>
 
   <style>
     @keyframes marquee { 0% { transform: translateX(100%); } 100% { transform: translateX(-100%); } }

--- a/templates/offline.html
+++ b/templates/offline.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Connect to Wi-Fi</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 2rem; background: #f7f7f7; }
+    h1 { color: #333; }
+    #networks > div { margin: 0.5rem 0; }
+    button { padding: 0.4rem 0.8rem; margin-left: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Offline</h1>
+  <p>No network connection detected. Select a Wi-Fi network to connect.</p>
+  <div id="networks">Scanning...</div>
+  <div id="status"></div>
+  <script>
+    async function scan() {
+      try {
+        const res = await fetch('/wifi/scan');
+        const data = await res.json();
+        const container = document.getElementById('networks');
+        container.innerHTML = '';
+        if (!data.networks || data.networks.length === 0) {
+          container.textContent = 'No networks found.';
+          return;
+        }
+        data.networks.forEach(net => {
+          const row = document.createElement('div');
+          row.textContent = `${net.ssid} (${net.signal}%)`;
+          const btn = document.createElement('button');
+          if (net.connected) {
+            btn.textContent = 'Connected';
+            btn.disabled = true;
+          } else {
+            btn.textContent = 'Connect';
+            btn.onclick = () => connect(net.ssid);
+          }
+          row.appendChild(btn);
+          container.appendChild(row);
+        });
+      } catch (e) {
+        document.getElementById('networks').textContent = 'Scan failed.';
+      }
+    }
+    async function connect(ssid) {
+      const password = prompt('Password for ' + ssid + ' (leave blank if open):', '');
+      const res = await fetch('/wifi/connect', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ssid, password: password || '' })
+      });
+      const data = await res.json();
+      document.getElementById('status').textContent = data.message || data.status;
+      if (data.status === 'ok') {
+        setTimeout(() => window.location.replace('/'), 2000);
+      }
+    }
+    window.addEventListener('online', () => window.location.replace('/'));
+    scan();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- reference local Tailwind CSS and bundled JS instead of CDN links
- add offline detection script that redirects to splash page
- scaffold build config and placeholder bundle for Vue and HLS

## Testing
- `python -m py_compile app.py`
- `pytest`
- `npx tailwindcss -i ./src/input.css -o ./static/css/tailwind.css --minify` *(fails: 403 Forbidden)*
- `npx esbuild src/main.js --bundle --minify --outfile=static/js/bundle.js` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_689e972d793c832c81878e6c41431db2