### PR TITLE
Fix followed boats settings key

### DIFF
--- a/app.py
+++ b/app.py
@@ -1182,9 +1182,11 @@ def save_emailed_events():
 
 def get_followed_boats():
     settings = load_settings()
-    return [normalize_boat_name(b) for b in settings.get("followed_boots", [])]  # typo preserved? fix:
-    # NOTE: If you had a historical typo in settings, handle both:
-    # return [normalize_boat_name(b) for b in settings.get("followed_boats", []) or settings.get("followed_boots", [])]
+    # Older configs stored "followed boats" under a misspelled key. Prefer the
+    # correct key but fall back to the legacy one so users don't lose their
+    # selections.
+    boats = settings.get("followed_boats") or settings.get("followed_boots", [])
+    return [normalize_boat_name(b) for b in boats]
 
 def _find_bt_sink_name(mac: str) -> str | None:
     """Return Pulse/PipeWire sink name for a BT device MAC (underscored)."""


### PR DESCRIPTION
## Summary
- Ensure `get_followed_boats` reads both the correct `followed_boats` key and the legacy `followed_boots` key so user selections (and their audio cues) work again

## Testing
- `python3 -m py_compile app.py && echo "py_compile passed"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689eb09265d8832c91a096b9e1d543a4