### PR TITLE
Inject PULSE_SERVER into audio environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -940,6 +940,7 @@ def _audio_env():
     env = os.environ.copy()
     env["XDG_RUNTIME_DIR"] = f"/run/user/{_AUDIO_UID}"
     env["PULSE_RUNTIME_PATH"] = f"/run/user/{_AUDIO_UID}/pulse"
+    env["PULSE_SERVER"] = f"unix:/run/user/{_AUDIO_UID}/pulse/native"
     return env
 
 def _sudo_prefix():
@@ -953,7 +954,8 @@ def _sudo_prefix():
             "sudo", "-u", AUDIO_USER,
             "env",
             f"XDG_RUNTIME_DIR={env['XDG_RUNTIME_DIR']}",
-            f"PULSE_RUNTIME_PATH={env['PULSE_RUNTIME_PATH']}"
+            f"PULSE_RUNTIME_PATH={env['PULSE_RUNTIME_PATH']}",
+            f"PULSE_SERVER={env['PULSE_SERVER']}"
         ]
     return []
 


### PR DESCRIPTION
## Summary
- set `PULSE_SERVER` in `_audio_env` so subprocesses target the user's PulseAudio socket
- propagate `PULSE_SERVER` through `sudo` invocation to preserve audio routing when running as root

## Testing
- `python -m py_compile app.py`
- `pytest`
- `pactl list sinks` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ed29723c4832c97015f0cd60c13f5