### PR TITLE
Persist VHF radio across pages

### DIFF
--- a/static/js/vhf.js
+++ b/static/js/vhf.js
@@ -1,0 +1,73 @@
+(function(){
+  const STORAGE_PLAYING = 'vhfPlaying';
+  const STORAGE_VOLUME = 'vhfVolume';
+  let hls = null;
+  let streamUrl = null;
+  const audio = document.getElementById('radio-player') || (() => {
+    const a = document.createElement('audio');
+    a.id = 'radio-player';
+    a.hidden = true;
+    document.body.appendChild(a);
+    return a;
+  })();
+
+  function updateButton(isPlaying){
+    const btn = document.querySelector('[data-vhf-toggle]');
+    if(btn) btn.textContent = isPlaying ? 'VHF OFF' : 'VHF ON';
+  }
+  function updateVolumeDisplay(v){
+    const span = document.querySelector('[data-vhf-volume-display]');
+    if(span) span.textContent = v + '%';
+  }
+  async function getStream(){
+    if(streamUrl) return streamUrl;
+    try{
+      const s = await fetch('/api/settings').then(r=>r.json());
+      const t = s.tournament;
+      const all = await fetch('https://js9467.github.io/Brtourney/settings.json').then(r=>r.json());
+      streamUrl = all[t]?.stream || all[t]?.fallback_stream || '';
+    }catch(e){console.error('stream fetch failed',e);}
+    return streamUrl;
+  }
+  async function play(){
+    const url = await getStream();
+    if(!url){alert('No VHF stream available.');return;}
+    if(window.Hls && Hls.isSupported()){
+      if(!hls) hls = new Hls();
+      hls.loadSource(url);
+      hls.attachMedia(audio);
+      hls.on(Hls.Events.MANIFEST_PARSED,()=>{audio.play().catch(()=>{});});
+    }else{
+      audio.src = url;
+      audio.play().catch(()=>{});
+    }
+    localStorage.setItem(STORAGE_PLAYING,'true');
+    updateButton(true);
+  }
+  function stop(){
+    audio.pause();
+    localStorage.setItem(STORAGE_PLAYING,'false');
+    updateButton(false);
+  }
+  async function toggle(){
+    if(audio.paused) await play(); else stop();
+  }
+  function applyVolume(v){
+    audio.volume = v/100;
+    localStorage.setItem(STORAGE_VOLUME, v);
+    updateVolumeDisplay(v);
+  }
+  document.addEventListener('DOMContentLoaded',()=>{
+    const btn = document.querySelector('[data-vhf-toggle]');
+    const vol = document.querySelector('[data-vhf-volume]');
+    if(btn) btn.addEventListener('click',toggle);
+    if(vol) vol.addEventListener('input', e=>applyVolume(e.target.value));
+    const savedVol = localStorage.getItem(STORAGE_VOLUME);
+    const v = savedVol !== null ? Number(savedVol) : (vol?Number(vol.value):30);
+    if(vol) { vol.value = v; updateVolumeDisplay(v); }
+    applyVolume(v);
+    if(localStorage.getItem(STORAGE_PLAYING)==='true'){
+      play();
+    }else updateButton(false);
+  });
+})();

--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -6,6 +6,7 @@
   <title>Leaderboard</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
   <link rel="stylesheet" href="/static/css/base.css" />
 </head>
 <body class="bg-gray-100 text-gray-800 font-sans overflow-y-auto">
@@ -16,10 +17,20 @@
         <img v-if="tournamentLogo" :src="tournamentLogo" alt="Tournament Logo" class="h-14 drop-shadow" />
         <span v-else class="text-white text-base">Loading Logo...</span>
       </div>
-      <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
+      <div class="flex items-center gap-3">
+        <div class="flex items-center gap-3 bg-blue-900/50 backdrop-blur-sm rounded-full px-4 py-2 shadow-md border border-yellow-400/70 animate-pulse-slow">
+          <button data-vhf-toggle class="px-4 py-2 w-28 sm:w-32 font-semibold border border-yellow-400 text-yellow-400 rounded-full hover:bg-yellow-400 hover:text-blue-900 transition shadow-md">VHF ON</button>
+          <div class="flex items-center gap-2 text-sm text-white flex-nowrap">
+            <span class="text-lg">🔊</span>
+            <input type="range" min="0" max="100" data-vhf-volume class="h-1 bg-yellow-400 rounded-lg appearance-none cursor-pointer w-24 sm:w-32 md:w-40 flex-shrink-0 accent-yellow-400">
+            <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
+          </div>
+        </div>
+        <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
+      </div>
     </header>
 
-    <div class="p-4 max-w-screen-xl mx-auto">
+  <div class="p-4 max-w-screen-xl mx-auto">
       <!-- Heading -->
       <header class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-4">
         <h1 class="text-4xl font-bold text-yellow-600">Tournament Leaderboard</h1>
@@ -84,6 +95,10 @@
       </div>
     </div>
   </div>
+
+  <audio id="radio-player" hidden></audio>
+
+  <script src="/static/js/vhf.js"></script>
 
   <script>
   const app = Vue.createApp({

--- a/static/participants.html
+++ b/static/participants.html
@@ -6,6 +6,7 @@
   <title>Participants</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
   <link rel="stylesheet" href="/static/css/base.css" />
   <style>[v-cloak]{display:none}</style>
 </head>
@@ -17,7 +18,17 @@
         <img v-if="tournamentLogo" :src="tournamentLogo" alt="Tournament Logo" class="h-14 drop-shadow" />
         <span v-else class="text-white text-base">Loading Logo...</span>
       </div>
-      <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
+      <div class="flex items-center gap-3">
+        <div class="flex items-center gap-3 bg-blue-900/50 backdrop-blur-sm rounded-full px-4 py-2 shadow-md border border-yellow-400/70 animate-pulse-slow">
+          <button data-vhf-toggle class="px-4 py-2 w-28 sm:w-32 font-semibold border border-yellow-400 text-yellow-400 rounded-full hover:bg-yellow-400 hover:text-blue-900 transition shadow-md">VHF ON</button>
+          <div class="flex items-center gap-2 text-sm text-white flex-nowrap">
+            <span class="text-lg">🔊</span>
+            <input type="range" min="0" max="100" data-vhf-volume class="h-1 bg-yellow-400 rounded-lg appearance-none cursor-pointer w-24 sm:w-32 md:w-40 flex-shrink-0 accent-yellow-400">
+            <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
+          </div>
+        </div>
+        <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
+      </div>
     </header>
 
     <div class="p-4 max-w-screen-xl mx-auto">
@@ -105,6 +116,10 @@
       </div>
     </div>
   </div>
+
+  <audio id="radio-player" hidden></audio>
+
+  <script src="/static/js/vhf.js"></script>
 
   <script>
   const app = Vue.createApp({

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -6,6 +6,7 @@
   <title>Release Summary</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link rel="stylesheet" href="/static/css/base.css">
   <style>
@@ -22,6 +23,14 @@
       <span v-else class="text-white text-base">Loading Logo...</span>
     </div>
     <div class="flex items-center gap-3">
+      <div class="flex items-center gap-3 bg-blue-900/50 backdrop-blur-sm rounded-full px-4 py-2 shadow-md border border-yellow-400/70 animate-pulse-slow">
+        <button data-vhf-toggle class="px-4 py-2 w-28 sm:w-32 font-semibold border border-yellow-400 text-yellow-400 rounded-full hover:bg-yellow-400 hover:text-blue-900 transition shadow-md">VHF ON</button>
+        <div class="flex items-center gap-2 text-sm text-white flex-nowrap">
+          <span class="text-lg">🔊</span>
+          <input type="range" min="0" max="100" data-vhf-volume class="h-1 bg-yellow-400 rounded-lg appearance-none cursor-pointer w-24 sm:w-32 md:w-40 flex-shrink-0 accent-yellow-400">
+          <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
+        </div>
+      </div>
       <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
     </div>
   </header>
@@ -321,6 +330,9 @@ createApp({
   }
 }).mount('#app');
 </script>
+
+<audio id="radio-player" hidden></audio>
+<script src="/static/js/vhf.js"></script>
 
 </body>
 </html>

--- a/static/settings.html
+++ b/static/settings.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.jsdelivr.net/npm/vue@3.4.15/dist/vue.global.prod.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/axios@1.6.8/dist/axios.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
   <link rel="stylesheet" href="/static/css/base.css">
   <style>
     body { touch-action: manipulation; }
@@ -26,6 +27,14 @@
         <span v-else class="text-white text-base">Loading Logo...</span>
       </div>
       <div class="flex items-center gap-3">
+        <div class="flex items-center gap-3 bg-blue-900/50 backdrop-blur-sm rounded-full px-4 py-2 shadow-md border border-yellow-400/70 animate-pulse-slow">
+          <button data-vhf-toggle class="px-4 py-2 w-28 sm:w-32 font-semibold border border-yellow-400 text-yellow-400 rounded-full hover:bg-yellow-400 hover:text-blue-900 transition shadow-md">VHF ON</button>
+          <div class="flex items-center gap-2 text-sm text-white flex-nowrap">
+            <span class="text-lg">🔊</span>
+            <input type="range" min="0" max="100" data-vhf-volume class="h-1 bg-yellow-400 rounded-lg appearance-none cursor-pointer w-24 sm:w-32 md:w-40 flex-shrink-0 accent-yellow-400">
+            <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
+          </div>
+        </div>
         <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Home</a>
       </div>
     </header>
@@ -222,6 +231,10 @@
       </div>
     </div>
   </div>
+
+  <audio id="radio-player" hidden></audio>
+
+  <script src="/static/js/vhf.js"></script>
 
   <script>
   const { createApp } = Vue;

--- a/templates/index.html
+++ b/templates/index.html
@@ -210,6 +210,14 @@ const vm = createApp({
 
     const player=document.getElementById('radio-player');
     if(player) player.volume=this.settings.radio_volume/100;
+    const savedVol=localStorage.getItem('vhfVolume');
+    if(savedVol!==null){
+      this.settings.radio_volume=Number(savedVol);
+      this.applyRadioVolume();
+    }
+    if(localStorage.getItem('vhfPlaying')==='true'){
+      this.toggleRadio();
+    }
 
     // Console sound test helpers
     window.playFollowed = () => this.playSound(this.settings.followed_sound);
@@ -311,10 +319,10 @@ const vm = createApp({
     },
     formatTime(ts){const dt=this.parseTs(ts);return dt?dt.toLocaleTimeString('en-US',{hour:'numeric',minute:'2-digit',hour12:true}):'';},
     formatDate(ts){const dt=this.parseTs(ts);return dt?dt.toLocaleDateString('en-US',{month:'numeric',day:'numeric'}):'';},
-    applyRadioVolume(){const p=document.getElementById('radio-player');if(p)p.volume=this.settings.radio_volume/100;},
+    applyRadioVolume(){const p=document.getElementById('radio-player');if(p)p.volume=this.settings.radio_volume/100;localStorage.setItem('vhfVolume',this.settings.radio_volume);},
     toggleRadio(){
       const p=document.getElementById('radio-player');if(!p)return;
-      if(this.radioPlaying){p.pause();this.radioPlaying=false;}
+      if(this.radioPlaying){p.pause();this.radioPlaying=false;localStorage.setItem('vhfPlaying','false');}
       else{
         fetch('/api/settings').then(r=>r.json()).then(s=>{
           const t=s.tournament;
@@ -329,7 +337,7 @@ const vm = createApp({
               }else{
                 p.src=stream;p.play();
               }
-              this.radioPlaying=true;
+              this.radioPlaying=true;localStorage.setItem('vhfPlaying','true');
             }else alert('No VHF stream available.');
           });
         });


### PR DESCRIPTION
## Summary
- remember VHF radio playing state and volume in localStorage
- add shared VHF control script for non-index pages
- mount VHF controls on participants, leaderboard, release summary, and settings pages so playback resumes when navigating

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ee3f93290832c803aee24486cb83b