### PR TITLE
feat: better followed boat handling and notification filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -1502,9 +1502,23 @@ def get_followed_boats():
     settings = load_settings()
     # Older configs stored "followed boats" under a misspelled key. Prefer the
     # correct key but fall back to the legacy one so users don't lose their
-    # selections.
+    # selections. The structure now supports per‑tournament lists, but we keep
+    # backward compatibility with a flat list.
     boats = settings.get("followed_boats") or settings.get("followed_boots", [])
+    if isinstance(boats, dict):
+        tournament = get_current_tournament()
+        boats = boats.get(tournament, [])
     return [normalize_boat_name(b) for b in boats]
+
+
+def get_all_followed_boats():
+    """Return mapping of tournament -> followed boats (raw names)."""
+    settings = load_settings()
+    boats = settings.get("followed_boats") or settings.get("followed_boots", [])
+    if isinstance(boats, list):
+        tournament = get_current_tournament()
+        return {tournament: boats}
+    return boats
 
 def _build_pactl_env(user: str) -> dict | None:
     """Return env vars so pactl talks to user's Pulse/PipeWire session."""
@@ -1571,7 +1585,7 @@ def should_email(event):
     uid = event.get("uid", "")
     if "boated" in etype:
         return True
-    followed_boats = [normalize_boat_name(b) for b in load_settings().get("followed_boats", [])]
+    followed_boats = get_followed_boats()
     return uid in followed_boats
 
 def process_new_event(event):
@@ -1591,26 +1605,25 @@ def process_new_event(event):
 def background_event_emailer():
     """Continuously watches new events and sends emails (respects demo/live)."""
     global emailed_events
-    emailed_events = load_emailed_events()
-    print(f"📡 Email watcher started. Loaded {len(emailed_events)} previous notifications.")
-    try:
-        # Preload last 50 as already-emailed to avoid flood
-        tournament = get_current_tournament()
-        events_file = get_cache_path(tournament, "events.json")
-        events = safe_json_load(events_file, [])
-        events.sort(key=lambda e: e["timestamp"], reverse=True)
-        for e in events[:50]:
-            key = f"{e.get('timestamp')}_{e.get('uid')}_{e.get('event')}"
-            emailed_events.add(key)
-        save_emailed_events()
-        print(f"⏩ Preloaded {min(50, len(events))} events as already emailed")
-    except Exception as e:
-        print(f"⚠️ Failed to preload events: {e}")
+    emailed_events = set()
+    current_tournament = get_current_tournament()
+    tournament_start = datetime.now()
+    print(
+        f"📡 Email watcher started. Emails will be sent for {current_tournament} events after {tournament_start.isoformat()}"
+    )
 
     while True:
         try:
             settings = load_settings()
             tournament = get_current_tournament()
+            if tournament != current_tournament:
+                current_tournament = tournament
+                tournament_start = datetime.now()
+                emailed_events.clear()
+                save_emailed_events()
+                print(
+                    f"🔁 Switched to {tournament}. Only events after {tournament_start.isoformat()} will trigger emails."
+                )
             if settings.get("data_source") == "demo":
                 data = load_demo_data(tournament)
                 events = data.get("events", [])
@@ -1621,6 +1634,12 @@ def background_event_emailer():
                 events = safe_json_load(events_file, [])
             events.sort(key=lambda e: e["timestamp"], reverse=True)
             for e in events[:50]:
+                try:
+                    event_time = date_parser.parse(e["timestamp"])
+                except Exception:
+                    continue
+                if event_time < tournament_start:
+                    continue
                 process_new_event(e)
         except Exception as e:
             print(f"⚠️ Email watcher error: {e}")
@@ -2253,8 +2272,7 @@ def release_summary_data():
 # ------------------------
 @app.route('/followed-boats', methods=['GET'])
 def get_followed_boats_api():
-    settings = load_settings()
-    return jsonify(settings.get("followed_boats", []))
+    return jsonify(get_all_followed_boats())
 
 @app.route('/followed-boats/toggle', methods=['POST'])
 def toggle_followed_boat():
@@ -2262,16 +2280,21 @@ def toggle_followed_boat():
     boat = data.get("boat")
     if not boat:
         return jsonify({"status": "error", "message": "Missing 'boat'"}), 400
+    tournament = data.get("tournament") or get_current_tournament()
     settings = load_settings()
-    followed = settings.get("followed_boats", [])
+    followed = settings.get("followed_boats", {})
+    if isinstance(followed, list):
+        followed = {tournament: followed}
+    boats = followed.get(tournament, [])
     uid = normalize_boat_name(boat)
-    followed_norm = [normalize_boat_name(b) for b in followed]
-    if uid in followed_norm:
-        followed = [b for b in followed if normalize_boat_name(b) != uid]
+    boats_norm = [normalize_boat_name(b) for b in boats]
+    if uid in boats_norm:
+        boats = [b for b in boats if normalize_boat_name(b) != uid]
         action = "unfollowed"
     else:
-        followed.append(boat)
+        boats.append(boat)
         action = "followed"
+    followed[tournament] = boats
     settings["followed_boats"] = followed
     safe_json_dump(SETTINGS_FILE, settings)
     return jsonify({"status": "ok", "action": action, "followed_boats": followed})

--- a/static/participants.html
+++ b/static/participants.html
@@ -128,6 +128,7 @@
         participants: [],
         followed: [],
         tournamentLogo: '',
+        tournament: '',
         search: '',
         loading: false,
         pollInterval: null,
@@ -150,7 +151,8 @@
       async loadFollowed() {
         try {
           const res = await fetch('/followed-boats');
-          this.followed = await res.json();
+          const data = await res.json();
+          this.followed = data[this.tournament] || [];
         } catch(e) {
           console.error('Failed to load followed boats', e);
         }
@@ -160,11 +162,11 @@
           const res = await fetch('/followed-boats/toggle', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ boat })
+            body: JSON.stringify({ boat, tournament: this.tournament })
           });
           const data = await res.json();
           if (data.status === 'ok') {
-            this.followed = data.followed_boats;
+            this.followed = data.followed_boats[this.tournament] || [];
           }
         } catch(e) {
           console.error('Toggle follow failed', e);
@@ -194,11 +196,11 @@
         try {
           const settingsRes = await fetch('/api/settings');
           const settings = await settingsRes.json();
-          const tournament = settings.tournament;
+          this.tournament = settings.tournament;
           const configRes = await fetch('https://js9467.github.io/Brtourney/settings.json');
           const allTournaments = await configRes.json();
-          this.tournamentLogo = allTournaments[tournament]?.logo || '';
-          this.setBrandColor(tournament, allTournaments);
+          this.tournamentLogo = allTournaments[this.tournament]?.logo || '';
+          this.setBrandColor(this.tournament, allTournaments);
         } catch(e) { console.error('Logo load failed', e); }
       },
       launchKeyboard() {
@@ -249,9 +251,8 @@
       }
     },
     mounted() {
-      this.loadLogo();
+      this.loadLogo().then(()=>this.loadFollowed());
       this.loadParticipants();
-      this.loadFollowed();
       this.startPolling();
     },
     beforeUnmount() { if (this.pollInterval) clearInterval(this.pollInterval); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,12 +84,17 @@
     </div>
 
     <!-- Followed Boats Chips -->
-    <div v-if="followed.length" class="mt-2 overflow-x-auto">
-      <div class="flex gap-2">
-        <div v-for="boat in followed" :key="boat"
-             class="flex items-center bg-yellow-200 text-blue-900 px-3 py-1 rounded-full text-sm font-semibold flex-shrink-0">
-          {{ boat }}
-          <button @click="toggleFollow(boat)" class="ml-1 text-red-600 hover:text-red-800">✕</button>
+    <div v-if="Object.keys(followed).length" class="mt-2 overflow-x-auto">
+      <div class="flex flex-col gap-2">
+        <div v-for="(boats, tourney) in followed" :key="tourney">
+          <div class="text-xs font-bold text-yellow-200">{{ tourney }}</div>
+          <div class="flex gap-2 mt-1">
+            <div v-for="boat in boats" :key="tourney + boat"
+                 class="flex items-center bg-yellow-200 text-blue-900 px-3 py-1 rounded-full text-sm font-semibold flex-shrink-0">
+              {{ boat }}
+              <button @click="toggleFollow(boat, tourney)" class="ml-1 text-red-600 hover:text-red-800">✕</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -193,7 +198,7 @@ const vm = createApp({
     return {
       events: [], hooked: [], boatImages: {},
       tournamentLogo: '', tournamentDate: '', version: '', loading: false,
-      followed: [], lastEventTimestamps: new Set(),
+      followed: {}, lastEventTimestamps: new Set(), tournamentStart: new Date(),
       settings: { followed_sound:'', boated_sound:'', hooked_sound:'', event_volume:80, radio_volume:30, sounds_enabled:true, data_source:'live', tournament:'' },
       radioPlaying:false, hls:null, error:null,
       messageQueue:[], currentMessage:'', messageTimer:null
@@ -262,9 +267,9 @@ const vm = createApp({
         });
     },
 
-    async loadFollowed(){ try{ const r=await fetch('/followed-boats'); this.followed=await r.json(); }catch{this.followed=[];} },
-    async toggleFollow(boat){
-      try{ const r=await fetch('/followed-boats/toggle',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({boat})});
+    async loadFollowed(){ try{ const r=await fetch('/followed-boats'); this.followed=await r.json(); }catch{this.followed={};} },
+    async toggleFollow(boat,tournament=this.settings.tournament){
+      try{ const r=await fetch('/followed-boats/toggle',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({boat,tournament})});
         const data=await r.json(); if(data.status==='ok') this.followed=data.followed_boats;
       }catch(e){console.error('toggleFollow failed',e);}
     },
@@ -275,7 +280,8 @@ const vm = createApp({
         .replace(/[\u0300-\u036f]/g,'')
         .replace(/[^a-z0-9]+/g,'_')
         .replace(/^_+|_+$/g,'');
-      return this.followed.some(b=>norm(b)===norm(uid));
+      const list=this.followed[this.settings.tournament]||[];
+      return list.some(b=>norm(b)===norm(uid));
     },
     playSound(f){
       if(!f||!this.settings.sounds_enabled)return;
@@ -295,7 +301,9 @@ const vm = createApp({
             const k=e.timestamp+e.uid;
             const isNew=!this.lastEventTimestamps.has(k);
             this.lastEventTimestamps.add(k);
-            if(isNew && this.settings.sounds_enabled){
+            const eventTime=this.parseTs(e.timestamp);
+            const afterStart=!this.tournamentStart|| (eventTime&&eventTime>=this.tournamentStart);
+            if(isNew && afterStart && this.settings.sounds_enabled){
               const et=(e.event||'').toLowerCase();
               if(et.includes('boated')) this.playSound(this.settings.boated_sound);
               else if(et.includes('hooked up')) this.playSound(this.settings.hooked_sound);
@@ -306,7 +314,18 @@ const vm = createApp({
         }).catch(()=>{this.loading=false;});
     },
 
-    fetchSettings(){return fetch('/api/settings').then(r=>r.json()).then(d=>{this.settings={...this.settings,...d};});},
+    fetchSettings(){
+      return fetch('/api/settings')
+        .then(r=>r.json())
+        .then(d=>{
+          const prev=this.settings.tournament;
+          this.settings={...this.settings,...d};
+          if(prev!==this.settings.tournament){
+            this.tournamentStart=new Date();
+            this.lastEventTimestamps=new Set();
+          }
+        });
+    },
     fetchVersion(){fetch('/api/version').then(r=>r.json()).then(d=>{this.version=d.version;});},
     loadParticipants(){fetch('/participants_data').then(r=>r.json()).then(d=>{const imgs={...this.boatImages};for(const p of d.participants)imgs[p.uid]=p.image_path;imgs['palmer_lou']='/static/images/palmer_lou.jpg';this.boatImages=imgs;});},
     getBoatImage(uid){return this.boatImages[uid]||'/static/images/bigrock.webp';},


### PR DESCRIPTION
## Summary
- avoid email floods by only emailing events after the tournament is opened
- avoid sound floods by only playing sounds for events after the tournament is opened
- store followed boats per tournament and expose API updates
- show followed boats grouped by tournament in UI and allow cross-tournament toggling

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f3d531ee8832c8e940e48ffbcc4e4