### PR TITLE
Use global fallback VHF stream

### DIFF
--- a/static/js/vhf.js
+++ b/static/js/vhf.js
@@ -25,7 +25,7 @@
       const s = await fetch('/api/settings').then(r=>r.json());
       const t = s.tournament;
       const all = await fetch('https://js9467.github.io/Brtourney/settings.json').then(r=>r.json());
-      streamUrl = all[t]?.stream || all[t]?.fallback_stream || '';
+      streamUrl = (all[t] && all[t].stream) || all.fallback_stream || '';
     }catch(e){console.error('stream fetch failed',e);}
     return streamUrl;
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -365,7 +365,7 @@ const vm = createApp({
         fetch('/api/settings').then(r=>r.json()).then(s=>{
           const t=s.tournament;
           fetch('https://js9467.github.io/Brtourney/settings.json').then(r=>r.json()).then(all=>{
-            const stream=all[t]?.stream||all[t]?.fallback_stream;
+            const stream=(all[t]&&all[t].stream)||all.fallback_stream;
             if(stream){
               if(Hls.isSupported()){
                 if(!this.hls)this.hls=new Hls();


### PR DESCRIPTION
## Summary
- Load tournament VHF stream with fallback to global `fallback_stream` value
- Adjust generic VHF JS utility to use global fallback stream

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f60b3cb5c832cb45be6a72518b3cb