### PR TITLE
Add spinner and optimize release summary data

### DIFF
--- a/app.py
+++ b/app.py
@@ -2280,6 +2280,7 @@ def release_summary_data():
             events = safe_json_load(events_file, [])
 
         summary = defaultdict(lambda: {"blue_marlins": 0, "white_marlins": 0, "sailfish": 0, "total_releases": 0})
+        release_events = []
 
         for e in events:
             if e["event"].lower() != "released":
@@ -2289,6 +2290,7 @@ def release_summary_data():
                 day = dt.strftime("%Y-%m-%d")
             except:
                 continue
+            release_events.append(e)
             details = e.get("details", "").lower()
             if "blue marlin" in details:
                 summary[day]["blue_marlins"] += 1
@@ -2300,7 +2302,7 @@ def release_summary_data():
 
         result = [{"date": k, **v} for k, v in sorted(summary.items(), key=lambda x: x[0], reverse=True)]
         return jsonify({"status": "ok", "demo_mode": demo_mode,
-                        "summary": result, "events": events})
+                        "summary": result, "events": release_events})
     except Exception as e:
         print(f"❌ Error generating release summary: {e}")
         return jsonify({"status": "error", "message": str(e)})

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -44,7 +44,13 @@
   <div class="p-6 max-w-6xl mx-auto w-full">
     <h1 class="text-2xl font-bold text-brand-blue mb-4">Release Summary</h1>
 
-    <div v-if="loading" class="text-gray-500 italic">Loading release summary...</div>
+    <div v-if="loading" class="text-gray-500 italic flex items-center">
+      <svg class="animate-spin h-5 w-5 mr-2 text-brand-blue" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+      </svg>
+      Loading release summary...
+    </div>
     <div v-else>
       <!-- Table -->
       <table class="w-full border border-gray-300 bg-white rounded shadow-md overflow-hidden mb-8">
@@ -100,7 +106,13 @@
         <h2 class="text-xl font-bold text-brand-blue">Releases for {{ formatDate(selectedDate) }}</h2>
         <button @click="closeModal" class="text-gray-500 hover:text-red-500 text-xl font-bold">&times;</button>
       </div>
-      <div v-if="drilldownLoading" class="text-gray-500 italic">Loading boat details...</div>
+      <div v-if="drilldownLoading" class="text-gray-500 italic flex items-center">
+        <svg class="animate-spin h-4 w-4 mr-2 text-brand-blue" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        Loading boat details...
+      </div>
       <div v-else class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         <div v-for="boat in drilldownBoats" :key="boat.uid" class="bg-white rounded shadow p-4 flex flex-col items-center border hover:shadow-lg">
           <img :src="boat.image || tournamentLogo" class="w-24 h-24 object-cover rounded mb-2" @error="e => e.target.src = tournamentLogo"/>


### PR DESCRIPTION
## Summary
- Show animated spinner while release summary charts or drilldowns are loading
- Return only release events from the `/release-summary-data` API to reduce payload size

## Testing
- `npm test` (fails: Error: no test specified)
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6126c550832cbda2bf217a04135b