### PR TITLE
feat: add shared nautical navigation bar

### DIFF
--- a/static/components/nav.html
+++ b/static/components/nav.html
@@ -1,0 +1,14 @@
+<nav class="bg-brand-blue text-white shadow-md">
+  <div class="max-w-screen-xl mx-auto flex items-center justify-between px-4 py-3">
+    <div class="flex items-center gap-4">
+      <img id="nav-logo" src="/static/images/bigrock.webp" alt="Tournament Logo" class="h-10" />
+    </div>
+    <div class="flex gap-4 text-sm font-semibold">
+      <a href="/" class="hover:text-brand-gold">Home</a>
+      <a href="/participants" class="hover:text-brand-gold">Participants</a>
+      <a href="/leaderboard" class="hover:text-brand-gold">Leaderboard</a>
+      <a href="/release-summary" class="hover:text-brand-gold">Releases</a>
+      <a href="/settings-page" class="hover:text-brand-gold">Settings</a>
+    </div>
+  </div>
+</nav>

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const placeholder = document.getElementById('nav-placeholder');
+  if (!placeholder) return;
+  fetch('/static/components/nav.html')
+    .then(res => res.text())
+    .then(html => {
+      placeholder.innerHTML = html;
+    })
+    .catch(err => console.error('Failed to load navigation', err));
+});

--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/static/css/base.css" />
 </head>
 <body class="bg-gray-100 text-gray-800 font-sans overflow-y-auto">
+  <div id="nav-placeholder"></div>
   <div id="app" v-cloak>
     <!-- Header -->
     <header class="bg-brand-blue text-white flex items-center justify-between px-4 py-3 shadow-md">
@@ -26,7 +27,6 @@
             <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
           </div>
         </div>
-        <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
       </div>
     </header>
 
@@ -212,5 +212,6 @@
   </script>
 
   <style>[v-cloak]{display:none}</style>
+  <script src="/static/js/nav.js"></script>
 </body>
 </html>

--- a/static/participants.html
+++ b/static/participants.html
@@ -11,6 +11,7 @@
   <style>[v-cloak]{display:none}</style>
 </head>
 <body class="bg-gray-100 text-gray-800 font-sans overflow-y-auto">
+  <div id="nav-placeholder"></div>
   <div id="app" v-cloak>
     <!-- Header -->
     <header class="bg-brand-blue text-white flex items-center justify-between px-4 py-3 shadow-md">
@@ -27,7 +28,6 @@
             <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
           </div>
         </div>
-        <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
       </div>
     </header>
 
@@ -259,5 +259,7 @@
   });
   app.mount('#app');
   </script>
+
+  <script src="/static/js/nav.js"></script>
 </body>
 </html>

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -14,6 +14,7 @@
   </style>
 </head>
 <body class="bg-gray-100 text-gray-800 font-sans overflow-y-auto">
+<div id="nav-placeholder"></div>
 <div id="app">
 
   <!-- Header: Logo + Back -->
@@ -31,7 +32,6 @@
           <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
         </div>
       </div>
-      <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Back</a>
     </div>
   </header>
 
@@ -345,6 +345,8 @@ createApp({
 
 <audio id="radio-player" hidden></audio>
 <script src="/static/js/vhf.js"></script>
+
+<script src="/static/js/nav.js"></script>
 
 </body>
 </html>

--- a/static/settings.html
+++ b/static/settings.html
@@ -19,6 +19,7 @@
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 font-sans overflow-y-auto">
+  <div id="nav-placeholder"></div>
   <div id="app">
     <!-- Header -->
     <header class="bg-brand-blue text-white flex items-center justify-between px-4 py-3 shadow-md">
@@ -35,7 +36,6 @@
             <span data-vhf-volume-display class="w-8 text-right text-xs"></span>
           </div>
         </div>
-        <a href="/" class="px-4 py-2 text-white font-semibold border border-white rounded hover:bg-white hover:text-blue-900 transition">Home</a>
       </div>
     </header>
 
@@ -464,5 +464,7 @@
     }
   }).mount('#app');
   </script>
+
+  <script src="/static/js/nav.js"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
 </head>
 
 <body class="bg-gray-100 text-gray-900 font-sans h-screen overflow-x-hidden">
+<div id="nav-placeholder"></div>
 <div id="app" class="h-full flex flex-col">
 
   <!-- Header (non-scrolling) -->
@@ -73,13 +74,7 @@
           </div>
         </div>
 
-        <!-- Navigation Buttons -->
-        <div class="grid grid-cols-2 sm:flex gap-2 sm:gap-4 w-full sm:w-auto text-center">
-          <a href="/participants" class="px-3 py-2 w-full sm:w-36 text-white font-semibold border border-yellow-400 rounded-lg hover:bg-yellow-400 hover:text-blue-900 transition shadow-md hover:shadow-yellow-400/50">Participants</a>
-          <a href="/leaderboard" class="px-3 py-2 w-full sm:w-36 text-white font-semibold border border-yellow-400 rounded-lg hover:bg-yellow-400 hover:text-blue-900 transition shadow-md hover:shadow-yellow-400/50">Leaderboard</a>
-          <a href="/release-summary" class="px-3 py-2 w-full sm:w-36 text-white font-semibold border border-yellow-400 rounded-lg hover:bg-yellow-400 hover:text-blue-900 transition shadow-md hover:shadow-yellow-400/50">Releases</a>
-          <a href="/settings-page" class="w-12 h-12 flex items-center justify-center text-white text-xl border border-yellow-400 rounded-full hover:bg-yellow-400 hover:text-blue-900 transition shadow-md hover:shadow-yellow-400/50">⚙</a>
-        </div>
+        <!-- Navigation now loaded via nav component -->
       </div>
     </div>
 
@@ -405,6 +400,8 @@ const vm = createApp({
 
 window.vm = vm;
 </script>
+
+<script src="/static/js/nav.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable Tailwind-based navigation component with nautical styling
- inject navigation bar into index, settings, participants, leaderboard and release summary pages

## Testing
- `npm test` (fails: Error: no test specified)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f63d744d8832cb2094d4e441247f3