### PR TITLE
Handle array responses for followed boats

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -268,21 +268,29 @@ const vm = createApp({
     },
 
 
+    normalizeFollowed(data){
+      const obj=(data && typeof data==="object" && !Array.isArray(data))
+        ? data
+        : { [this.settings.tournament]: data || [] };
+      const cleaned={};
+      for(const k in obj){
+        const v=obj[k];
+        if(Array.isArray(v) && v.length) cleaned[k]=v;
+      }
+      return cleaned;
+    },
     async loadFollowed(){
       try{
         const r=await fetch('/followed-boats');
         const data=await r.json();
-
-        const obj=(data && typeof data==="object" && !Array.isArray(data))
-          ? data
-          : { [this.settings.tournament]: data || [] };
-        this.followed=Object.fromEntries(Object.entries(obj).filter(([k,v])=>Array.isArray(v)&&v.length));
+        this.followed=this.normalizeFollowed(data);
       }catch{this.followed={};}
     },
     async toggleFollow(boat,tournament=this.settings.tournament){
-      try{ const r=await fetch('/followed-boats/toggle',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({boat,tournament})});
-        const data=await r.json(); if(data.status==='ok') this.followed=Object.fromEntries(Object.entries(data.followed_boats||{}).filter(([k,v])=>Array.isArray(v)&&v.length));
-
+      try{
+        const r=await fetch('/followed-boats/toggle',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({boat,tournament})});
+        const data=await r.json();
+        if(data.status==='ok') this.followed=this.normalizeFollowed(data.followed_boats);
       }catch(e){console.error('toggleFollow failed',e);}
     },
     isFollowed(uid){


### PR DESCRIPTION
## Summary
- Normalize backend responses for followed boats
- Reuse normalization for load and toggle follow actions
- Avoid `Object.fromEntries` for broader browser support

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f68a76d84832c8d0ff551e1f0a6c7