### PR TITLE
Fix followed boats processing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -276,12 +276,25 @@ const vm = createApp({
         const obj=(data && typeof data==="object" && !Array.isArray(data))
           ? data
           : { [this.settings.tournament]: data || [] };
-        this.followed=Object.fromEntries(Object.entries(obj).filter(([k,v])=>Array.isArray(v)&&v.length));
+
+        const filtered={};
+        for(const [k,v] of Object.entries(obj)){
+          if(Array.isArray(v) && v.length) filtered[k]=v;
+        }
+        this.followed=filtered;
       }catch{this.followed={};}
     },
     async toggleFollow(boat,tournament=this.settings.tournament){
-      try{ const r=await fetch('/followed-boats/toggle',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({boat,tournament})});
-        const data=await r.json(); if(data.status==='ok') this.followed=Object.fromEntries(Object.entries(data.followed_boats||{}).filter(([k,v])=>Array.isArray(v)&&v.length));
+      try{
+        const r=await fetch('/followed-boats/toggle',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({boat,tournament})});
+        const data=await r.json();
+        if(data.status==='ok'){
+          const filtered={};
+          for(const [k,v] of Object.entries(data.followed_boats||{})){
+            if(Array.isArray(v) && v.length) filtered[k]=v;
+          }
+          this.followed=filtered;
+        }
 
       }catch(e){console.error('toggleFollow failed',e);}
     },


### PR DESCRIPTION
## Summary
- avoid Object.fromEntries to support older browsers when tracking followed boats

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fe631d350832cabd70e845e1f9896