### PR TITLE
Fix demo mode events to respect current time

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request, send_from_directory, send_file, abort, redirect
 from dateutil import parser as date_parser
 from datetime import datetime, timedelta, time as dt_time
+from zoneinfo import ZoneInfo
 import json
 import os
 from bs4 import BeautifulSoup
@@ -474,6 +475,9 @@ def inject_hooked_up_events(events, tournament=None):
                 "details": "Hooked up!",
                 "hookup_id": key
             })
+            # Attach the same hookup_id to the resolution event so we can
+            # pair them later when filtering unresolved hooks
+            event["hookup_id"] = key
             inserted_keys.add(key)
         except Exception as e:
             print(f"⚠️ Demo injection failed for {boat}: {e}")
@@ -1321,14 +1325,19 @@ def scrape_events_route():
 
         all_events = data.get("events", [])
 
-        now = datetime.now()
+        eastern = ZoneInfo("America/New_York")
+        now = datetime.now(eastern)
         today = now.date()
 
         filtered = []
         for e in all_events:
             try:
                 original_ts = date_parser.parse(e["timestamp"])
-                ts = datetime.combine(today, original_ts.time())
+                if original_ts.tzinfo is None:
+                    original_ts = original_ts.replace(tzinfo=eastern)
+                else:
+                    original_ts = original_ts.astimezone(eastern)
+                ts = datetime.combine(today, original_ts.timetz())
             except Exception:
                 continue
 
@@ -1788,19 +1797,36 @@ def get_hooked_up_events():
     settings = load_settings()
     tournament = get_current_tournament()
     data_source = settings.get("data_source", "live").lower()
-    now_time = datetime.now().time()
+    eastern = ZoneInfo("America/New_York")
+    now = datetime.now(eastern)
 
     if data_source == "demo":
         data = load_demo_data(tournament)
-        events = [e for e in data.get("events", []) if date_parser.parse(e["timestamp"]).time() <= now_time]
+        events = []
+        for e in data.get("events", []):
+            try:
+                original_ts = date_parser.parse(e["timestamp"])
+                if original_ts.tzinfo is None:
+                    original_ts = original_ts.replace(tzinfo=eastern)
+                else:
+                    original_ts = original_ts.astimezone(eastern)
+                event_dt = datetime.combine(now.date(), original_ts.timetz())
+            except Exception:
+                continue
+            if event_dt <= now:
+                adjusted = dict(e)
+                adjusted["timestamp"] = event_dt.isoformat()
+                events.append(adjusted)
+
         # unresolved only (use hookup_id resolution pairing)
         resolved_ids = set()
         for e in events:
             if e["event"] in ["Released", "Boated"] or \
                "pulled hook" in e.get("details", "").lower() or \
                "wrong species" in e.get("details", "").lower():
-                key = f"{e['uid']}_{date_parser.parse(e['timestamp']).replace(microsecond=0).isoformat()}"
-                resolved_ids.add(key)
+                key = e.get("hookup_id")
+                if key:
+                    resolved_ids.add(key)
         hooked_feed = []
         for e in events:
             if e["event"] != "Hooked Up":
@@ -2216,8 +2242,21 @@ def release_summary_data():
         if demo_mode:
             data = load_demo_data(tournament)
             all_events = data.get("events", [])
-            now = datetime.now()
-            events = [e for e in all_events if date_parser.parse(e["timestamp"]).time() <= now.time()]
+            eastern = ZoneInfo("America/New_York")
+            now = datetime.now(eastern)
+            events = []
+            for e in all_events:
+                try:
+                    ts = date_parser.parse(e["timestamp"])
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=eastern)
+                    else:
+                        ts = ts.astimezone(eastern)
+                    event_today = datetime.combine(now.date(), ts.timetz())
+                except Exception:
+                    continue
+                if event_today <= now:
+                    events.append(e)
         else:
             events_file = get_cache_path(tournament, "events.json")
             events = safe_json_load(events_file, [])


### PR DESCRIPTION
## Summary
- Ensure demo mode filters events and hooked-up feed using America/New_York timezone
- Avoid showing future events in release summary when running in demo mode
- Resolve demo mode hook events by tagging resolution events and matching on `hookup_id`

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68a0a5688ce4832cb52790c7d0a0ca6d