### PR TITLE
Redirect to offline page when WiFi unavailable

### DIFF
--- a/static/js/offline.js
+++ b/static/js/offline.js
@@ -1,0 +1,18 @@
+(function(){
+  function goOffline(){
+    window.location.href = '/offline';
+  }
+  function checkConnection(){
+    const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    const onWifi = conn && conn.type ? conn.type === 'wifi' : true;
+    if(!navigator.onLine || !onWifi){
+      goOffline();
+    }
+  }
+  checkConnection();
+  window.addEventListener('offline', goOffline);
+  const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  if(conn && conn.addEventListener){
+    conn.addEventListener('change', checkConnection);
+  }
+})();

--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Leaderboard</title>
+  <script src="/static/js/offline.js"></script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>

--- a/static/participants.html
+++ b/static/participants.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Participants</title>
+  <script src="/static/js/offline.js"></script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>

--- a/static/release-summary.html
+++ b/static/release-summary.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Release Summary</title>
+  <script src="/static/js/offline.js"></script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>

--- a/static/settings.html
+++ b/static/settings.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Settings</title>
+  <script src="/static/js/offline.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vue@3.4.15/dist/vue.global.prod.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/axios@1.6.8/dist/axios.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/static/wifi.html
+++ b/static/wifi.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wi-Fi Setup</title>
+    <script src="/static/js/offline.js"></script>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,16 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Events Feed</title>
-  <script>
-    function goOffline() {
-      window.location.href = '/offline';
-    }
-    if (!navigator.onLine) {
-      goOffline();
-    } else {
-      window.addEventListener('offline', goOffline);
-    }
-  </script>
+  <script src="/static/js/offline.js"></script>
   <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>


### PR DESCRIPTION
## Summary
- add shared `offline.js` script that routes users to `/offline` when WiFi is missing
- load the new script on index and all static pages so offline users see the offline lane

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10e29c920832ca57b130b655bfe66